### PR TITLE
URL Cleanup

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -71,7 +71,7 @@
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/doc/reference/lib/fop-0.95/lib/README.txt
+++ b/doc/reference/lib/fop-0.95/lib/README.txt
@@ -5,7 +5,7 @@ Information on Apache FOP dependencies
 $Id$
 
 The Apache Licenses can also be found here:
-http://www.apache.org/licenses/
+https://www.apache.org/licenses/
 
 
 Normal Dependencies

--- a/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/avalon-framework.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/batik.LICENSE.txt
@@ -1,6 +1,6 @@
                                   Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-io.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/commons-logging.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/serializer.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xalan.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xercesImpl.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis-ext.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xml-apis.LICENSE.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
+++ b/doc/reference/lib/fop-0.95/lib/xmlgraphics-commons.LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/ConnectionFactoryUtils.cs
+++ b/src/Spring.Erlang/Connection/ConnectionFactoryUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/ConnectionParameters.cs
+++ b/src/Spring.Erlang/Connection/ConnectionParameters.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/DefaultConnection.cs
+++ b/src/Spring.Erlang/Connection/DefaultConnection.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/IConnection.cs
+++ b/src/Spring.Erlang/Connection/IConnection.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/IConnectionFactory.cs
+++ b/src/Spring.Erlang/Connection/IConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/IConnectionProxy.cs
+++ b/src/Spring.Erlang/Connection/IConnectionProxy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/SimpleConnectionFactory.cs
+++ b/src/Spring.Erlang/Connection/SimpleConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Connection/SingleConnectionFactory.cs
+++ b/src/Spring.Erlang/Connection/SingleConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Core/Application.cs
+++ b/src/Spring.Erlang/Core/Application.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Core/ConnectionCallbackDelegate.cs
+++ b/src/Spring.Erlang/Core/ConnectionCallbackDelegate.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Core/ErlangTemplate.cs
+++ b/src/Spring.Erlang/Core/ErlangTemplate.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Core/IErlangOperations.cs
+++ b/src/Spring.Erlang/Core/IErlangOperations.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Core/Node.cs
+++ b/src/Spring.Erlang/Core/Node.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/ErlangBadRpcException.cs
+++ b/src/Spring.Erlang/ErlangBadRpcException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/ErlangErrorRpcException.cs
+++ b/src/Spring.Erlang/ErlangErrorRpcException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/OtpIOException.cs
+++ b/src/Spring.Erlang/OtpIOException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Support/Converter/ErlangConversionException.cs
+++ b/src/Spring.Erlang/Support/Converter/ErlangConversionException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Support/Converter/IErlangConverter.cs
+++ b/src/Spring.Erlang/Support/Converter/IErlangConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Support/Converter/SimpleErlangConverter.cs
+++ b/src/Spring.Erlang/Support/Converter/SimpleErlangConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Support/ErlangAccessor.cs
+++ b/src/Spring.Erlang/Support/ErlangAccessor.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/Support/ErlangUtils.cs
+++ b/src/Spring.Erlang/Support/ErlangUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Erlang/UncategorizedOtpException.cs
+++ b/src/Spring.Erlang/UncategorizedOtpException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/ClientFactoryUtils.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/ClientFactoryUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/ConnectionParameters.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/ConnectionParameters.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/IClientFactory.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/IClientFactory.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/IResourceFactory.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/IResourceFactory.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/QpdResourceHolder.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/QpdResourceHolder.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/SimpleClientFactory.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Client/SimpleClientFactory.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/MessageCreatorDelegate.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/MessageCreatorDelegate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/MessageProperties.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/MessageProperties.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/QpidAccessor.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/QpidAccessor.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/QpidTemplate.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Core/QpidTemplate.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Support/QpidUtils.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-10-0.8/Spring.Messaging.Amqp.Qpid-0-10-0.8/Support/QpidUtils.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-8-0.8/Spring.Messaging.Amqp.Qpid-0-8-0.8/Core/HeadersDictionary.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-8-0.8/Spring.Messaging.Amqp.Qpid-0-8-0.8/Core/HeadersDictionary.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Qpid-0-8-0.8/Spring.Messaging.Amqp.Qpid-0-8-0.8/Core/MessageProperties.cs
+++ b/src/Spring.Messaging.Amqp.Qpid-0-8-0.8/Spring.Messaging.Amqp.Qpid-0-8-0.8/Core/MessageProperties.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/IRabbitBrokerOperations.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/IRabbitBrokerOperations.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/QueueInfo.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/QueueInfo.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitAdminAuthException.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitAdminAuthException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitBrokerAdmin.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitBrokerAdmin.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitControlErlangConverter.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitControlErlangConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitStatus.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit.Admin/Admin/RabbitStatus.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/AbstractExchangeParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/AbstractExchangeParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/AbstractRetryOperationsInterceptorFactoryObject.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/AbstractRetryOperationsInterceptorFactoryObject.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/AdminParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/AdminParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/BindingFactoryObject.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/BindingFactoryObject.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/ConnectionFactoryParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/ConnectionFactoryParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/DirectExchangeParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/DirectExchangeParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/FanoutExchangeParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/FanoutExchangeParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/FederatedExchangeParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/FederatedExchangeParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/HeadersExchangeParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/HeadersExchangeParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/ListenerContainerParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/ListenerContainerParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/NamespaceUtils.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/NamespaceUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/ObjectDefinitionParserHelper.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/ObjectDefinitionParserHelper.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/QueueArgumentsParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/QueueArgumentsParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/QueueParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/QueueParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/RabbitNamespaceHandler.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/RabbitNamespaceHandler.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/RabbitNamespaceUtils.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/RabbitNamespaceUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/TemplateParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/TemplateParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Config/TopicExchangeParser.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Config/TopicExchangeParser.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/AbstractConnectionFactory.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/AbstractConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/CachingConnectionFactory.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/CachingConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/CompositeChannelListener.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/CompositeChannelListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/CompositeConnectionListener.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/CompositeConnectionListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/ConnectionFactoryUtils.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/ConnectionFactoryUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IChannelListener.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IChannelListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IChannelProxy.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IChannelProxy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnection.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnection.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnectionFactory.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnectionListener.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnectionListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnectionProxy.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IConnectionProxy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IResourceFactory.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IResourceFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/IResourceHolder.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/IResourceHolder.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitAccessor.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitAccessor.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitResourceHolder.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitResourceHolder.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitResourceHolderSupport.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitResourceHolderSupport.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitResourceSynchronization.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitResourceSynchronization.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitUtils.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/RabbitUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/ResourceFactory.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/ResourceFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/ResourceHolderSynchronization.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/ResourceHolderSynchronization.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Connection/SimpleConnection.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Connection/SimpleConnection.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/ChannelCallbackDelegate.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/ChannelCallbackDelegate.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/IChannelAwareMessageListener.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/IChannelAwareMessageListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/IChannelCallback.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/IChannelCallback.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/IConfirmCallback.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/IConfirmCallback.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/IRabbitOperations.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/IRabbitOperations.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/IReturnCallback.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/IReturnCallback.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/RabbitAdmin.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/RabbitAdmin.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/RabbitTemplate.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/RabbitTemplate.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Core/Support/RabbitGatewaySupport.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Core/Support/RabbitGatewaySupport.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/AbstractMessageListenerContainer.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/AbstractMessageListenerContainer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/ActiveObjectCounter.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/ActiveObjectCounter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/Adapter/MessageListenerAdapter.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/Adapter/MessageListenerAdapter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/BlockingQueueConsumer.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/BlockingQueueConsumer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/ConsumerCancelledException.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/ConsumerCancelledException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/FatalListenerExecutionException.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/FatalListenerExecutionException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/FatalListenerStartupException.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/FatalListenerStartupException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/ListenerExecutionFailedException.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/ListenerExecutionFailedException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/MessageRejectedWhileStoppingException.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/MessageRejectedWhileStoppingException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Listener/SimpleMessageListenerContainer.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Listener/SimpleMessageListenerContainer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Retry/IMessageKeyGenerator.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Retry/IMessageKeyGenerator.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Retry/IMessageRecoverer.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Retry/IMessageRecoverer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Retry/INewMessageIdentifier.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Retry/INewMessageIdentifier.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Retry/MissingMessageIdAdvice.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Retry/MissingMessageIdAdvice.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Retry/RejectAndDontRequeueRecoverer.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Retry/RejectAndDontRequeueRecoverer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/CollectionExtensions.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/CollectionExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/CorrelationData.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/CorrelationData.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/DateExtensions.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/DateExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/DefaultMessagePropertiesConverter.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/DefaultMessagePropertiesConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/IMessagePropertiesConverter.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/IMessagePropertiesConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/IPublisherCallbackChannel.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/IPublisherCallbackChannel.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/IPublisherCallbackChannelListener.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/IPublisherCallbackChannelListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/PendingConfirm.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/PendingConfirm.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/PublisherCallbackChannelImpl.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/PublisherCallbackChannelImpl.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Support/XmlElementExtensions.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Support/XmlElementExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Threading/AtomicTypes/AtomicBoolean.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Threading/AtomicTypes/AtomicBoolean.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Threading/AtomicTypes/AtomicInteger.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Threading/AtomicTypes/AtomicInteger.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Threading/AtomicTypes/AtomicReference.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Threading/AtomicTypes/AtomicReference.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Transaction/RabbitAbstractPlatformTransactionManager.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Transaction/RabbitAbstractPlatformTransactionManager.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Transaction/RabbitTransactionManager.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Transaction/RabbitTransactionManager.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Transaction/RabbitTransactionSynchronizationManager.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Transaction/RabbitTransactionSynchronizationManager.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp.Rabbit/Transaction/TransactionSynchronizationUtils.cs
+++ b/src/Spring.Messaging.Amqp.Rabbit/Transaction/TransactionSynchronizationUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/AmqpConnectException.cs
+++ b/src/Spring.Messaging.Amqp/AmqpConnectException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/AmqpException.cs
+++ b/src/Spring.Messaging.Amqp/AmqpException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/AmqpIOException.cs
+++ b/src/Spring.Messaging.Amqp/AmqpIOException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/AmqpIllegalStateException.cs
+++ b/src/Spring.Messaging.Amqp/AmqpIllegalStateException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/AmqpRejectAndDontRequeueException.cs
+++ b/src/Spring.Messaging.Amqp/AmqpRejectAndDontRequeueException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/AmqpUnsupportedEncodingException.cs
+++ b/src/Spring.Messaging.Amqp/AmqpUnsupportedEncodingException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/AbstractExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/AbstractExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/AcknowledgeMode.cs
+++ b/src/Spring.Messaging.Amqp/Core/AcknowledgeMode.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/Address.cs
+++ b/src/Spring.Messaging.Amqp/Core/Address.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/AnonymousQueue.cs
+++ b/src/Spring.Messaging.Amqp/Core/AnonymousQueue.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/Binding.cs
+++ b/src/Spring.Messaging.Amqp/Core/Binding.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/BindingBuilder.cs
+++ b/src/Spring.Messaging.Amqp/Core/BindingBuilder.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/CustomExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/CustomExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/DirectExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/DirectExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/ExchangeType.cs
+++ b/src/Spring.Messaging.Amqp/Core/ExchangeType.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/FanoutExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/FanoutExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/FederatedExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/FederatedExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/HeadersExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/HeadersExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/IAmqpAdmin.cs
+++ b/src/Spring.Messaging.Amqp/Core/IAmqpAdmin.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/IAmqpTemplate.cs
+++ b/src/Spring.Messaging.Amqp/Core/IAmqpTemplate.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/IExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/IExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/IMessageListener.cs
+++ b/src/Spring.Messaging.Amqp/Core/IMessageListener.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/IMessagePostProcessor.cs
+++ b/src/Spring.Messaging.Amqp/Core/IMessagePostProcessor.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/Message.cs
+++ b/src/Spring.Messaging.Amqp/Core/Message.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/MessageDeliveryMode.cs
+++ b/src/Spring.Messaging.Amqp/Core/MessageDeliveryMode.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/MessageProperties.cs
+++ b/src/Spring.Messaging.Amqp/Core/MessageProperties.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/Queue.cs
+++ b/src/Spring.Messaging.Amqp/Core/Queue.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/TopicExchange.cs
+++ b/src/Spring.Messaging.Amqp/Core/TopicExchange.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Core/UniquelyNamedQueue.cs
+++ b/src/Spring.Messaging.Amqp/Core/UniquelyNamedQueue.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/ImmediateAcknowledgeAmqpException.cs
+++ b/src/Spring.Messaging.Amqp/ImmediateAcknowledgeAmqpException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/AbstractMessageConverter.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/AbstractMessageConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/DefaultTypeMapper.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/DefaultTypeMapper.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/IMessageConverter.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/IMessageConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/ITypeMapper.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/ITypeMapper.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/JsonMessageConverter.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/JsonMessageConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/MessageConversionException.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/MessageConversionException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/Converter/SimpleMessageConverter.cs
+++ b/src/Spring.Messaging.Amqp/Support/Converter/SimpleMessageConverter.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Support/DictionaryExtensions.cs
+++ b/src/Spring.Messaging.Amqp/Support/DictionaryExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/UncategorizedAmqpException.cs
+++ b/src/Spring.Messaging.Amqp/UncategorizedAmqpException.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/src/Spring.Messaging.Amqp/Utils/SerializationUtils.cs
+++ b/src/Spring.Messaging.Amqp/Utils/SerializationUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Erlang.Tests/Properties/AssemblyInfo.cs
+++ b/test/Spring.Erlang.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/AbstractExample.cs
+++ b/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/AbstractExample.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/ConsumerExample.cs
+++ b/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/ConsumerExample.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/ProducerExample.cs
+++ b/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/ProducerExample.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/TestConstants.cs
+++ b/test/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Spring.Messaging.Amqp.Qpid-0-10-0.8.Tests/Core/TestConstants.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Admin/ErlangNetIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Admin/ErlangNetIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Admin/RabbitBrokerAdminIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Admin/RabbitBrokerAdminIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Admin/RabbitBrokerAdminLifecycleIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Admin/RabbitBrokerAdminLifecycleIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Properties/AssemblyInfo.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Admin.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/AdminParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/AdminParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ConnectionFactoryParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ConnectionFactoryParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ExchangeParserIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ExchangeParserIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ExchangeParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ExchangeParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/FederatedExchangeParserIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/FederatedExchangeParserIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ListenerContainerParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ListenerContainerParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ListenerContainerPlaceholderParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/ListenerContainerPlaceholderParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueArgumentsParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueArgumentsParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueParserIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueParserIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueParserPlaceholderTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueParserPlaceholderTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/QueueParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/RabbitNamespaceHandlerTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/RabbitNamespaceHandlerTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/TemplateParserTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/TemplateParserTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/TestAdvice.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/TestAdvice.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/TestObject.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Config/TestObject.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/AbstractConnectionFactoryTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/AbstractConnectionFactoryTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/CachingConnectionFactoryIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/CachingConnectionFactoryIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/CachingConnectionFactoryTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/CachingConnectionFactoryTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/SharedConnectionProxy.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/SharedConnectionProxy.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/SingleConnectionFactory.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/SingleConnectionFactory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/SingleConnectionFactoryTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Connection/SingleConnectionFactoryTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/Producer.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/Producer.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/QueueUtils.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/QueueUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitAdminIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitAdminIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitAdminTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitAdminTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitBindingIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitBindingIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplateHeaderTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplateHeaderTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplateIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplateIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplatePerformanceIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplatePerformanceIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplateTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/RabbitTemplateTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/Support/RabbitGatewaySupportTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/Support/RabbitGatewaySupportTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/TestConstants.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Core/TestConstants.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/ActiveObjectCounterTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/ActiveObjectCounterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/Adapter/MessageListenerAdapterTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/Adapter/MessageListenerAdapterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/BlockingQueueConsumerIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/BlockingQueueConsumerIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/BlockingQueueConsumerTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/BlockingQueueConsumerTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/ExternalTxManagerTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/ExternalTxManagerTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/LocallyTransactedTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/LocallyTransactedTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerBrokerInterruptionIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerBrokerInterruptionIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerErrorHandlerIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerErrorHandlerIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerLifecycleIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerLifecycleIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerMultipleQueueIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerMultipleQueueIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerRetryIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerContainerRetryIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerManualAckIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerManualAckIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerRecoveryCachingConnectionIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerRecoveryCachingConnectionIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerRecoverySingleConnectionIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerRecoverySingleConnectionIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerTxSizeIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/MessageListenerTxSizeIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/SimpleMessageListenerContainerIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/SimpleMessageListenerContainerIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/SimpleMessageListenerContainerTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/SimpleMessageListenerContainerTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/StopStartIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/StopStartIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/UnackedRawIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Listener/UnackedRawIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Support/MoqExtensions.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Support/MoqExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/AbstractRabbitIntegrationTest.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/AbstractRabbitIntegrationTest.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerFederated.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerFederated.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerPanic.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerPanic.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerRunning.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerRunning.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerTestUtils.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/BrokerTestUtils.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/EnvironmentAvailable.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/EnvironmentAvailable.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/TestCategory.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/TestCategory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/XmlObjectFactoryExtensions.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Test/XmlObjectFactoryExtensions.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Rabbit.Tests/Transaction/RabbitTransactionManagerIntegrationTests.cs
+++ b/test/Spring.Messaging.Amqp.Rabbit.Tests/Transaction/RabbitTransactionManagerIntegrationTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Core/AddressTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Core/AddressTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Core/BindingBuilderTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Core/BindingBuilderTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Core/MessagePropertiesTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Core/MessagePropertiesTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Core/MessageTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Core/MessageTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Properties/AssemblyInfo.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Support/Converter/DefaultTypeMapperTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Support/Converter/DefaultTypeMapperTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Support/Converter/JsonMessageConverterTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Support/Converter/JsonMessageConverterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Support/Converter/MarshallingMessageConverterTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Support/Converter/MarshallingMessageConverterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Support/Converter/SerializerMessageConverterTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Support/Converter/SerializerMessageConverterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Support/Converter/SimpleMessageConverterTests.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Support/Converter/SimpleMessageConverterTests.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Support/Converter/SimpleTrade.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Support/Converter/SimpleTrade.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/test/Spring.Messaging.Amqp.Tests/Test/TestCategory.cs
+++ b/test/Spring.Messaging.Amqp.Tests/Test/TestCategory.cs
@@ -5,7 +5,7 @@
 //   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 //   the License. You may obtain a copy of the License at
 //   
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //   
 //   Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 //   an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 12 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 255 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).